### PR TITLE
feat(docker): Added docker and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,50 @@ users have taken. The system features collaborative management, so you can manag
 - [Documentation](https://hortusfox.github.io/)
 
 ## Installation
-1. [Manual installation](#manual-installation)
-2. [Using the Installer](#installer)
+1. [Docker and Docker Compose (Recommended)](#docker-and-docker-compose)
+2. [Manual installation](#manual-installation)
+3. [Using the Installer](#installer)
+
+### Docker and Docker Compose
+Using Docker and Docker Compose simplifies the setup process and ensures consistency across different environments. Follow these steps:
+
+Prerequisites
+- Docker installed on your system
+- Docker Compose installed on your system
+
+Steps
+
+1. Clone the repository:
+
+```shell
+git clone git@github.com:danielbrendel/hortusfox-web.git
+cd hortusfox-web
+```
+
+2. Run the application using Docker Compose:
+
+```shell
+docker-compose up -d
+```
+
+3. The application should now be running on http://localhost:8080.
+
+
+### Environment Variables
+Configure the application using environment variables.
+
+Set these in your docker-compose.yml file:
+
+| Variable           | Description            | Default           | Required |
+|--------------------|------------------------|-------------------|:--------:|
+| DB_HOST            | Database host          | db                |    Yes   |
+| DB_PORT            | Database port          | 3306              |    Yes   |
+| DB_DATABASE        | Database name          | hortusfox         |    Yes   |
+| DB_USERNAME        | Database user          | root              |    Yes   |
+| DB_PASSWORD        | Database password      | my-secret-pw      |    Yes   |
+| APP_DEBUG          | Enable debug mode      | false             |    No    |
+| HORTUSFOX_ADMIN    | Default admin email    | admin@example.com |    No    |
+| HORTUSFOX_PASSWORD | Default admin password | Auto-generated    |    No    |
 
 ### Manual Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  app:
+    image: danielbrendel/hortusfox-web:latest
+    ports:
+      - "8080:80"
+    environment:
+      APP_DEBUG: "false"
+      APP_BASEDIR: ""
+      APP_SESSION: "false"
+      APP_LANG: "en"
+      APP_WORKSPACE: "My home"
+      APP_ENABLESCROLLER: "true"
+      APP_OVERLAYALPHA: "null"
+      APP_ENABLECHAT: "false"
+      DB_ENABLE: "true"
+      DB_DRIVER: "mysql"
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_DATABASE: hortusfox
+      DB_USERNAME: root
+      DB_CHARSET: "utf8mb4"
+      DB_USER: root
+      DB_PASSWORD: my-secret-pw
+      # Add other environment variables here as needed
+    depends_on:
+      - db
+
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: my-secret-pw
+      MYSQL_DATABASE: hortusfox
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  db_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Default values for admin user and password
+DEFAULT_ADMIN_EMAIL="admin@example.com"
+DEFAULT_ADMIN_PASSWORD=$(openssl rand -base64 12)  # Generate a random password
+
+# Use environment variables if provided, otherwise use defaults
+ADMIN_EMAIL="${HORTUSFOX_ADMIN:-$DEFAULT_ADMIN_EMAIL}"
+ADMIN_PASSWORD="${HORTUSFOX_PASSWORD:-$DEFAULT_ADMIN_PASSWORD}"
+
+# Function to set PHP error reporting based on APP_DEBUG
+configure_php_error_reporting() {
+    if [ "$APP_DEBUG" = "false" ]; then
+        # Suppress warnings and notices if APP_DEBUG is false
+        echo 'error_reporting = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED' > /usr/local/etc/php/conf.d/errors.ini
+        echo 'display_errors = Off' >> /usr/local/etc/php/conf.d/errors.ini
+    else
+        # Show all errors if APP_DEBUG is true
+        echo 'error_reporting = E_ALL' > /usr/local/etc/php/conf.d/errors.ini
+        echo 'display_errors = On' >> /usr/local/etc/php/conf.d/errors.ini
+    fi
+}
+
+# Function to check if the admin user exists
+check_admin_user_exists() {
+    local user_count=$(mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -D "$DB_DATABASE" -N -s -e "SELECT COUNT(*) FROM users WHERE email='$ADMIN_EMAIL';")
+    if [[ $user_count -gt 0 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to create an admin user
+create_admin_user() {
+    # Use PHP to hash the password
+    local hashed_password=$(php -r "echo password_hash('$ADMIN_PASSWORD', PASSWORD_BCRYPT);")
+
+    # Insert the new admin user into the database
+    mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -D "$DB_DATABASE" -e "INSERT INTO users (id, name, email, password, password_reset, session, status, admin, lang, chatcolor, show_log, show_plants_aoru, notify_tasks_overdue, notify_tasks_tomorrow, last_seen_msg, last_typing, last_action, created_at) VALUES (NULL, 'Admin', '$ADMIN_EMAIL', '$hashed_password', NULL, NULL, 0, 1, NULL, NULL, 1, 1, 1, 1, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
+
+    echo "Admin user created. Username: $ADMIN_EMAIL, Password: $ADMIN_PASSWORD"
+}
+
+# Configure PHP error reporting
+configure_php_error_reporting
+
+# Run database migrations
+echo "Running database migrations..."
+php asatru migrate:fresh
+
+# Check if admin user exists
+if ! check_admin_user_exists; then
+    echo "Admin user ($ADMIN_EMAIL) does not exist. Creating..."
+    create_admin_user
+else
+    echo "Admin user ($ADMIN_EMAIL) already exists. Skipping user creation."
+fi
+
+# Then exec the container's main process (CMD)
+exec "$@"

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,57 @@
+# First stage: Composer installation
+FROM composer:latest as composer
+
+# Set the working directory in the Composer container
+WORKDIR /app
+
+# Copy the composer.json and composer.lock files
+COPY composer.json composer.lock ./
+
+# Install dependencies
+RUN composer install --no-scripts --no-autoloader
+
+# Optimize the autoloader
+RUN composer dump-autoload --optimize
+
+# Second stage: Apache + PHP setup
+FROM php:8.3.1-apache
+
+# Set the working directory
+WORKDIR /var/www/html
+
+# Copy the application source
+COPY . /var/www/html
+
+# Copy the Composer dependencies from the first stage
+COPY --from=composer /app/vendor/ /var/www/html/vendor/
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    unzip \
+    git \
+    default-mysql-client && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+
+# Enable Apache mod_rewrite for .htaccess support
+RUN a2enmod rewrite
+
+# Expose port 80
+EXPOSE 80
+
+# Copy docker-entrypoint.sh into the container
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Set the script as the entrypoint
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# Start Apache server (CMD)
+CMD ["apache2-foreground"]


### PR DESCRIPTION
I wanted to add a slightly less involved way of setting this up and developing using docker and docker desktop.

I added the following:

- `dockerfile`: contains the compose step, uses apache2 to run the webserver, uses some configs to make everything run.
- `docker-entrypoint.sh`: adds some automated steps to running the container. We now add a default user (`admin@example.com`) with an autogenerated password if none exists and if none was passed in environment values (`HORTUSFOX_ADMIN` and `HORTUSFOX_PASSWORD`). We also run migrations on every startup.
- `docker-compose.yml`: Creates a sample deployment with the hortusfox-web app and a mariadb:latest container. The environment variables work as-is for a simple setup but can be tweaked to match the user's needs. It also gives a sample deployment to go from.
- `readme.md`: I made the docker install the "default" install since it is pretty much the easiest and cleanest since we don't actually install anything on the host system.

Some things to note:
- the "official" docker image is not publicly available so users must build it themselves (easy enough with a `git clone` and then `docker build ./ -t danielbrendel/hortusfox-web:latest`.
- I added a table with environment variables that I found by digging around your projects, there might be more looming but I have not added them yet.

Next steps:
- adding a github-actions workflow to automatically create and publish this image as an artefact in this repo.
- document the rest of the env variables so the other users don't have to dig around like I did.

Closes #57 