### PR TITLE
feat(docker): Added max post and upload sizes to php.ini

### DIFF
--- a/99-php.ini
+++ b/99-php.ini
@@ -1,0 +1,2 @@
+upload_max_filesize = 15M
+post_max_size = 15M

--- a/dockerfile
+++ b/dockerfile
@@ -22,6 +22,9 @@ WORKDIR /var/www/html
 # Copy the application source
 COPY . /var/www/html
 
+# Copy the PHP overrides
+COPY ./99-php.ini /usr/local/etc/php/conf.d/
+
 # Copy the Composer dependencies from the first stage
 COPY --from=composer /app/vendor/ /var/www/html/vendor/
 


### PR DESCRIPTION
Fixes #60 by adding a php.ini file to add overrides into. It is read in alphabetical order so the 99 prefix makes it the final one.

Looks like the settings are well loaded, the values before were 8M.

```shell
root@hortusfox-7c997cd59b-ckmh8:/var/www/html# php -i | grep post_max_size
post_max_size => 15M => 15M
root@hortusfox-7c997cd59b-ckmh8:/var/www/html# php -i | grep upload_max_filesize
upload_max_filesize => 15M => 15M
```