### PR TITLE
add persistence for images and logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,13 @@
-version: '3.8'
+version: "3.8"
 
 services:
   app:
     image: danielbrendel/hortusfox-web:latest
     ports:
       - "8080:80"
+    volumes:
+      - "./plants:/var/www/html/public/img"
+      - "./plants_logs:/var/www/html/app/logs"
     environment:
       APP_DEBUG: "true"
       APP_LANG: "en"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -148,9 +148,15 @@ php asatru migrate:fresh
 # Check if admin user exists and create it if not.
 add_admin_user_if_missing
 
+# copy default images
+cp /tmp/img/* /var/www/html/public/img
+
 # Set permissions to folders for file upload
 chown -R www-data:www-data /var/www/html/public/img
 chmod -R 755 /var/www/html/public/img
+
+# Set permissions to folders for logs
+chown -R www-data:www-data /var/www/html/app/logs
 
 # Then exec the container's main process (CMD)
 exec "$@"

--- a/dockerfile
+++ b/dockerfile
@@ -22,6 +22,14 @@ WORKDIR /var/www/html
 # Copy the application source
 COPY . /var/www/html
 
+# copy default files in /public/img so they can be copied if needed in entrypoint
+RUN mkdir /tmp/img
+RUN cp /var/www/html/public/img/* /tmp/img
+VOLUME /var/www/html/public/img
+
+# Create volume for logs
+VOLUME /var/www/html/app/logs
+
 # Copy the PHP overrides
 COPY ./99-php.ini /usr/local/etc/php/conf.d/
 


### PR DESCRIPTION
Uploaded images and logs are now stored on individual docker volumes which can be mapped to the docker host's file system

#80 