### PR TITLE
feat: Add docker image tag for each version (in addition to latest)

### DIFF
--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -12,5 +12,5 @@ jobs:
       - name: Build and push the image
         run: |
           docker login --username danielbrendel --password ${{ secrets.GH_CONTAINER_REGISTRY }} ghcr.io
-          docker build . --tag ghcr.io/danielbrendel/hortusfox-web:latest
-          docker push ghcr.io/danielbrendel/hortusfox-web:latest
+          docker build . --tag ghcr.io/danielbrendel/hortusfox-web:latest --tag ghcr.io/danielbrendel/hortusfox-web:${{ github.ref_name }}
+          docker push --all-tags ghcr.io/danielbrendel/hortusfox-web


### PR DESCRIPTION
This will add a tagged image for the specific version, e.g. v1.0, v2.2, etc, for each image built.

You can see [this test run](https://github.com/boc-the-git/hortusfox-web/actions/runs/8029654204/job/21936186160) that shows the contents of `${{ github.ref_name }}` when a job is run based on a tag being pushed.

Fixes https://github.com/danielbrendel/hortusfox-web/issues/123