### PR TITLE
Remove admin password from the log file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,7 +121,7 @@ create_admin_user() {
     # Insert the new admin user into the database
     mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -D "$DB_DATABASE" -e "INSERT INTO users (id, name, email, password, password_reset, session, status, admin, lang, chatcolor, show_log, show_plants_aoru, notify_tasks_overdue, notify_tasks_tomorrow, last_seen_msg, last_typing, last_action, created_at) VALUES (NULL, 'Admin', '$ADMIN_EMAIL', '$hashed_password', NULL, NULL, 0, 1, NULL, NULL, 1, 1, 1, 1, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
 
-    echo "Admin user created. Username: $ADMIN_EMAIL
+    echo "Admin user created. Username: $ADMIN_EMAIL"
 }
 
 set_apache_server_name() {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,7 +121,7 @@ create_admin_user() {
     # Insert the new admin user into the database
     mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -D "$DB_DATABASE" -e "INSERT INTO users (id, name, email, password, password_reset, session, status, admin, lang, chatcolor, show_log, show_plants_aoru, notify_tasks_overdue, notify_tasks_tomorrow, last_seen_msg, last_typing, last_action, created_at) VALUES (NULL, 'Admin', '$ADMIN_EMAIL', '$hashed_password', NULL, NULL, 0, 1, NULL, NULL, 1, 1, 1, 1, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
 
-    echo "Admin user created. Username: $ADMIN_EMAIL, Password: $ADMIN_PASSWORD"
+    echo "Admin user created. Username: $ADMIN_EMAIL
 }
 
 set_apache_server_name() {


### PR DESCRIPTION
Simple PR to prevent outputting admin password to log on initial account creation. 

Fixes #127