### PR TITLE
 Disable/hide buttons when attribute unchecked #224 

### DIFF
--- a/app/views/plants.php
+++ b/app/views/plants.php
@@ -2,9 +2,15 @@
 
 <div class="margin-vertical">
 	<div class="is-inline-block is-action-button-margin"><a class="button is-success" href="javascript:void(0);" onclick="document.getElementById('inpLocationId').value = {{ $location }}; window.vue.bShowAddPlant = true;">{{ __('app.add_plant') }}</a></div>
+    @if (plant_attr('last_watered'))
 	<div class="is-inline-block is-action-button-margin"><a class="button is-info" href="javascript:void(0);" onclick="window.vue.showPerformBulkUpdate('last_watered', '{{ __('app.bulk_set_watered') }}', '{{ __('app.set_watered') }}');">{{ __('app.set_watered') }}</a></div>
+    @endif
+    @if (plant_attr('last_repotted'))
 	<div class="is-inline-block is-action-button-margin"><a class="button is-warning" href="javascript:void(0);" onclick="window.vue.showPerformBulkUpdate('last_repotted', '{{ __('app.bulk_set_repotted') }}', '{{ __('app.set_repotted') }}');">{{ __('app.set_repotted') }}</a></div>
+    @endif
+    @if (plant_attr('last_fertilised'))
 	<div class="is-inline-block is-action-button-margin"><a class="button is-chocolate" href="javascript:void(0);" onclick="window.vue.showPerformBulkUpdate('last_fertilised', '{{ __('app.bulk_set_fertilised') }}', '{{ __('app.set_fertilised') }}');">{{ __('app.set_fertilised') }}</a></div>
+    @endif
 	<div class="is-inline-block is-action-button-margin"><a class="button" href="javascript:void(0);" onclick="window.vue.bShowPlantBulkPrint = true;">{{ __('app.bulk_print_qr_codes') }}</a></div>
 	<div class="is-inline-block is-action-button-margin"><a class="is-default-link is-fixed-button-link is-fixed-margin-left-mobile" href="{{ url('/') }}">{{ __('app.back_to_dashboard') }}</a></div>
 </div>


### PR DESCRIPTION
When an attribute like last_watered, last_repotted and last_fertilised are unchecked so they don't appear as an attribute on plants the button under the location is still there and will set the attribute anyway. I believe a better thing would be to not display the button for attributes that are not activated.
Issue #224 
