### PR TITLE
fix(styling): insert inline styles before theme styling

### DIFF
--- a/app/views/head.php
+++ b/app/views/head.php
@@ -4,10 +4,6 @@
 <link rel="icon" type="image/png" href="{{ asset('logo.png') }}"/>
 <link rel="stylesheet" type="text/css" href="{{ asset('css/bulma.css') }}"/>
 
-@if ((ThemeModule::ready()) && (ThemeModule::data()->include))
-<link rel="stylesheet" type="text/css" href="{{ ThemeModule::data()->include }}"/>
-@endif
-
 @if (env('APP_DEBUG'))
 <script src="{{ asset('js/vue.js') }}"></script>
 @else
@@ -15,6 +11,13 @@
 @endif
 
 <script src="{{ asset('js/app.js', true) }}"></script>
+
+<!-- Marker: Webpack-injected styles go BEFORE this, theme styles load AFTER -->
+<meta name="webpack-styles-end" content="marker"/>
+
+@if ((ThemeModule::ready()) && (ThemeModule::data()->include))
+<link rel="stylesheet" type="text/css" href="{{ ThemeModule::data()->include }}"/>
+@endif
 
 @if ((ThemeModule::ready()) && (ThemeModule::data()->script))
 <script src="{{ ThemeModule::data()->script }}"></script>

--- a/app/views/head.php
+++ b/app/views/head.php
@@ -12,7 +12,6 @@
 
 <script src="{{ asset('js/app.js', true) }}"></script>
 
-<!-- Marker: Webpack-injected styles go BEFORE this, theme styles load AFTER -->
 <meta name="webpack-styles-end" content="marker"/>
 
 @if ((ThemeModule::ready()) && (ThemeModule::data()->include))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,22 @@ module.exports = {
       {
         test: /\.s[ac]ss$/i,
         use: [
-          // Creates `style` nodes from JS strings
-          'style-loader',
+          {
+            // Creates `style` nodes from JS strings
+            loader: 'style-loader',
+            options: {
+              // Insert styles BEFORE the marker, so theme CSS loads after and can override
+              insert: function(styleElement) {
+                const marker = document.querySelector('meta[name="webpack-styles-end"]');
+                if (marker) {
+                  marker.parentNode.insertBefore(styleElement, marker);
+                } else {
+                  // Fallback: insert at end of head
+                  document.head.appendChild(styleElement);
+                }
+              },
+            },
+          },
           // Translates CSS into CommonJS
           'css-loader',
           // Compiles Sass to CSS


### PR DESCRIPTION
Fix theme CSS being overridden by webpack-injected styles.

## Description
Webpack's style-loader injects CSS into <style> tags at the end of the <head> section, causing these styles to load after the theme's linked CSS file. This means webpack-generated styles override theme customizations, making it difficult for themes to properly style the app.