### PR TITLE
fix styling for full screen plant preview

### DIFF
--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -3700,3 +3700,18 @@ fieldset .field {
 .button-margin-left {
     margin-left: 5px;
 }
+
+.preview-image {
+    width: 80vw;
+    height: 80vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+
+    img {
+        vertical-align: middle;
+        max-width: 100%;
+        max-height: 100%;
+    }
+}

--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -3702,16 +3702,8 @@ fieldset .field {
 }
 
 .preview-image {
-    width: 80vw;
-    height: 80vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    max-width: 80vw;
+    max-height: 80vh;
+    vertical-align: middle;
     z-index: 1;
-
-    img {
-        vertical-align: middle;
-        max-width: 100%;
-        max-height: 100%;
-    }
 }

--- a/app/views/layout.php
+++ b/app/views/layout.php
@@ -1162,10 +1162,8 @@
 			<div class="modal" :class="{'is-active': bShowPreviewImageModal}">
 				<div class="modal-background" onclick="window.vue.bShowPreviewImageModal = false;"></div>
 
-				<div class="modal-content">
-					<p class="image">
+                <div class="preview-image">
 						<img id="preview-image-modal-img" alt="image">
-					</p>
 				</div>
 
 				<button class="modal-close is-large" aria-label="close" onclick="window.vue.bShowPreviewImageModal = false;"></button>

--- a/app/views/layout.php
+++ b/app/views/layout.php
@@ -1162,9 +1162,7 @@
 			<div class="modal" :class="{'is-active': bShowPreviewImageModal}">
 				<div class="modal-background" onclick="window.vue.bShowPreviewImageModal = false;"></div>
 
-                <div class="preview-image">
-						<img id="preview-image-modal-img" alt="image">
-				</div>
+				<img id="preview-image-modal-img" alt="image" class="preview-image">
 
 				<button class="modal-close is-large" aria-label="close" onclick="window.vue.bShowPreviewImageModal = false;"></button>
 			</div>


### PR DESCRIPTION
Resolves #491
Resolves #435

## Description
- Fix fullscreen plant image preview appearing skewed/distorted in the modal
- Replace Bulma's .modal-content > .image structure with a simpler .preview-image container
- Add flexbox centering and proper max-width/max-height constraints to preserve image aspect ratio