### PR TITLE
Add missing project name to testing env file

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -8,7 +8,7 @@
 #   string, integer, float, boolean and null (auto detected)
 
 # App settings
-APP_NAME="Asatru PHP"
+APP_NAME="HortusFox"
 APP_VERSION="5.7"
 APP_AUTHOR="Daniel Brendel"
 APP_CONTACT="dbrendel1988@gmail.com"


### PR DESCRIPTION
Project name was missing in `.env.testing`. Added correct name.